### PR TITLE
Transform partition test for Monty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ name = "bench"
 harness = false
 
 [profile.dev]
-opt-level = 2
+# opt-level = 2
 
 [profile.release]
 codegen-units = 1  # if > 1 enables parallel code generation which improves

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -143,7 +143,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let fi = FrameInvariants::<u16>::new(config, sequence);
   let mut fs = FrameState::new(&fi);
   let offset = BlockOffset { x: 1, y: 1 };
-  b.iter(|| rdo_cfl_alpha(&mut fs, offset, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling))
+  b.iter(|| rdo_cfl_alpha(&mut fs, &offset, bsize, fi.sequence.bit_depth))
 }
 
 criterion_group!(intra_prediction, predict::pred_bench,);

--- a/src/context.rs
+++ b/src/context.rs
@@ -119,6 +119,51 @@ static av1_tx_ind: [[usize; TX_TYPES]; TX_SETS] = [
   [7, 8, 9, 12, 10, 11, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
 ];
 
+pub static max_txsize_rect_lookup: [TxSize; BlockSize::BLOCK_SIZES_ALL] = [
+      // 4X4
+      TX_4X4,
+      // 4X8,    8X4,      8X8
+      TX_4X8,    TX_8X4,   TX_8X8,
+      // 8X16,   16X8,     16X16
+      TX_8X16,   TX_16X8,  TX_16X16,
+      // 16X32,  32X16,    32X32
+      TX_16X32,  TX_32X16, TX_32X32,
+      // 32X64,  64X32,
+      TX_32X64,  TX_64X32,
+      // 64X64
+      TX_64X64,
+      // 64x128, 128x64,   128x128
+      TX_64X64,  TX_64X64, TX_64X64,
+      // 4x16,   16x4,
+      TX_4X16,   TX_16X4,
+      // 8x32,   32x8
+      TX_8X32,   TX_32X8,
+      // 16x64,  64x16
+      TX_16X64,  TX_64X16
+];
+
+static sub_tx_size_map: [TxSize; TxSize::TX_SIZES_ALL] = [
+  TX_4X4,    // TX_4X4
+  TX_4X4,    // TX_8X8
+  TX_8X8,    // TX_16X16
+  TX_16X16,  // TX_32X32
+  TX_32X32,  // TX_64X64
+  TX_4X4,    // TX_4X8
+  TX_4X4,    // TX_8X4
+  TX_8X8,    // TX_8X16
+  TX_8X8,    // TX_16X8
+  TX_16X16,  // TX_16X32
+  TX_16X16,  // TX_32X16
+  TX_32X32,  // TX_32X64
+  TX_32X32,  // TX_64X32
+  TX_4X8,    // TX_4X16
+  TX_8X4,    // TX_16X4
+  TX_8X16,   // TX_8X32
+  TX_16X8,   // TX_32X8
+  TX_16X32,  // TX_16X64
+  TX_32X16,  // TX_64X16
+];
+
 static ss_size_lookup: [[[BlockSize; 2]; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   //  ss_x == 0    ss_x == 0        ss_x == 1      ss_x == 1
   //  ss_y == 0    ss_y == 1        ss_y == 0      ss_y == 1
@@ -700,6 +745,7 @@ pub struct CDFContext {
   intra_tx_cdf:
     [[[[u16; TX_TYPES + 1]; INTRA_MODES]; TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTRA],
   inter_tx_cdf: [[[u16; TX_TYPES + 1]; TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTER],
+  tx_size_cdf: [[[u16; MAX_TX_DEPTH + 1 + 1]; TX_SIZE_CONTEXTS]; MAX_TX_CATS],
   skip_cdfs: [[u16; 3]; SKIP_CONTEXTS],
   intra_inter_cdfs: [[u16; 3]; INTRA_INTER_CONTEXTS],
   angle_delta_cdf: [[u16; 2 * MAX_ANGLE_DELTA + 1 + 1]; DIRECTIONAL_MODES],
@@ -761,6 +807,7 @@ impl CDFContext {
       refmv_cdf: default_refmv_cdf,
       intra_tx_cdf: default_intra_ext_tx_cdf,
       inter_tx_cdf: default_inter_ext_tx_cdf,
+      tx_size_cdf: default_tx_size_cdf,
       skip_cdfs: default_skip_cdfs,
       intra_inter_cdfs: default_intra_inter_cdf,
       angle_delta_cdf: default_angle_delta_cdf,
@@ -839,6 +886,11 @@ impl CDFContext {
       self.inter_tx_cdf[2][i][12] = 0;
       self.inter_tx_cdf[3][i][2] = 0;
     }
+
+    for i in 0..TX_SIZE_CONTEXTS { self.tx_size_cdf[0][i][MAX_TX_DEPTH] = 0; }
+    reset_2d!(self.tx_size_cdf[1]);
+    reset_2d!(self.tx_size_cdf[2]);
+    reset_2d!(self.tx_size_cdf[3]);
 
     reset_2d!(self.skip_cdfs);
     reset_2d!(self.intra_inter_cdfs);
@@ -1251,6 +1303,8 @@ pub struct BlockContext {
   pub preskip_segid: bool,
   above_partition_context: Vec<u8>,
   left_partition_context: [u8; MAX_MIB_SIZE],
+  above_tx_context: Vec<u8>,
+  left_tx_context: [u8; MAX_MIB_SIZE],
   above_coeff_context: [Vec<u8>; PLANES],
   left_coeff_context: [[u8; MAX_MIB_SIZE]; PLANES],
   blocks: Vec<Vec<Block>>
@@ -1273,6 +1327,8 @@ impl BlockContext {
       preskip_segid: true,
       above_partition_context: vec![0; aligned_cols],
       left_partition_context: [0; MAX_MIB_SIZE],
+      above_tx_context: vec![0; aligned_cols],
+      left_tx_context: [0; MAX_MIB_SIZE],
       above_coeff_context: [
         vec![0; above_coeff_context_size],
         vec![0; above_coeff_context_size],
@@ -1293,6 +1349,8 @@ impl BlockContext {
       preskip_segid: self.preskip_segid,
       above_partition_context: self.above_partition_context.clone(),
       left_partition_context: self.left_partition_context,
+      above_tx_context: self.above_tx_context.clone(),
+      left_tx_context: self.left_tx_context,
       above_coeff_context: self.above_coeff_context.clone(),
       left_coeff_context: self.left_coeff_context,
       blocks: vec![vec![Block::default(); 0]; 0]
@@ -1305,6 +1363,8 @@ impl BlockContext {
     self.cdef_coded = checkpoint.cdef_coded;
     self.above_partition_context = checkpoint.above_partition_context.clone();
     self.left_partition_context = checkpoint.left_partition_context;
+    self.above_tx_context = checkpoint.above_tx_context.clone();
+    self.left_tx_context = checkpoint.left_tx_context;
     self.above_coeff_context = checkpoint.above_coeff_context.clone();
     self.left_coeff_context = checkpoint.left_coeff_context;
   }
@@ -1386,7 +1446,39 @@ impl BlockContext {
       *c = 0;
     }
   }
-  //TODO(anyone): Add reset_left_tx_context() here then call it in reset_left_contexts()
+
+  pub fn update_tx_size_context(
+    &mut self, bo: BlockOffset, bsize: BlockSize, tx_size: TxSize, skip: bool
+  ) {
+    let n4_w = bsize.width_mi();
+    let n4_h = bsize.height_mi();
+    let mut tx_w = tx_size.width() as u8;
+    let mut tx_h = tx_size.height() as u8;
+
+    let above_ctx =
+      &mut self.above_tx_context[bo.x..bo.x + n4_w as usize];
+    let left_ctx = &mut self.left_tx_context
+      [bo.y_in_sb()..bo.y_in_sb() + n4_h as usize];
+
+    if skip {
+      tx_w = n4_w as u8;
+      tx_h = n4_h as u8;
+    }
+
+    for i in 0..n4_w {
+      above_ctx[i as usize] = tx_w;
+    }
+
+    for i in 0..n4_h {
+      left_ctx[i as usize] = tx_h;
+    }
+  }
+
+  fn reset_left_tx_context(&mut self) {
+    for c in &mut self.left_tx_context {
+      *c = 0;
+    }
+  }
 
   pub fn reset_skip_context(
     &mut self, bo: BlockOffset, bsize: BlockSize, xdec: usize, ydec: usize
@@ -1435,7 +1527,7 @@ impl BlockContext {
     }
     BlockContext::reset_left_partition_context(self);
 
-    //TODO(anyone): Call reset_left_tx_context() here.
+    BlockContext::reset_left_tx_context(self);
   }
 
   pub fn set_mode(
@@ -1450,10 +1542,10 @@ impl BlockContext {
     self.for_each(bo, bsize, |block| { block.n4_w = n4_w; block.n4_h = n4_h } );
   }
 
-  pub fn set_tx_size(&mut self, bo: BlockOffset, txsize: TxSize) {
+  pub fn set_tx_size(&mut self, bo: BlockOffset, bsize: BlockSize, txsize: TxSize) {
     let tx_w = txsize.width_mi();
     let tx_h = txsize.height_mi();
-    self.for_each(bo, txsize.block_size(), |block| { block.tx_w = tx_w; block.tx_h = tx_h } );
+    self.for_each(bo, bsize, |block| { block.tx_w = tx_w; block.tx_h = tx_h } );
   }
 
   pub fn get_mode(&mut self, bo: BlockOffset) -> PredictionMode {
@@ -1949,6 +2041,81 @@ impl ContextWriter {
       w.symbol((p == PartitionType::PARTITION_SPLIT) as u32, &cdf);
     }
   }
+
+  pub fn get_tx_size_context(&self, bo: BlockOffset, bsize: BlockSize) -> usize {
+    let max_tx_size = max_txsize_rect_lookup[bsize as usize];
+    let max_tx_wide = max_tx_size.width();
+    let max_tx_high = max_tx_size.height();
+    let has_above = bo.y > 0;
+    let has_left = bo.x > 0;
+    let mut above = self.bc.above_tx_context[bo.x] >= max_tx_wide as u8;
+    let mut left = self.bc.left_tx_context[bo.y_in_sb()] >= max_tx_high as u8;
+
+    if has_above {
+      let above_blk = self.bc.above_of(bo);
+      if above_blk.is_inter() { above = (above_blk.n4_w << MI_SIZE_LOG2) >= max_tx_wide; };
+    }
+    if has_left {
+      let left_blk = self.bc.left_of(bo);
+      if left_blk.is_inter() { left = (left_blk.n4_h << MI_SIZE_LOG2) >= max_tx_high; };
+    }
+    if has_above && has_left { return above as usize + left as usize };
+    if has_above { return above as usize};
+    if has_left { return left as usize};
+    return 0
+  }
+
+  pub fn write_tx_size_intra(&mut self, w: &mut dyn Writer, bo: BlockOffset,
+                          bsize: BlockSize, tx_size: TxSize) {
+    fn tx_size_to_depth(tx_size: TxSize, bsize: BlockSize ) -> usize {
+      let mut ctx_size = max_txsize_rect_lookup[bsize as usize];
+      let mut depth: usize = 0;
+      while tx_size != ctx_size {
+        depth += 1;
+        ctx_size = sub_tx_size_map[ctx_size as usize];
+        debug_assert!(depth <= MAX_TX_DEPTH);
+      }
+      depth
+    }
+    fn bsize_to_max_depth(bsize: BlockSize) -> usize {
+      let mut tx_size: TxSize = max_txsize_rect_lookup[bsize as usize];
+      let mut depth = 0;
+      while depth < MAX_TX_DEPTH && tx_size != TX_4X4 {
+        depth += 1;
+        tx_size = sub_tx_size_map[tx_size as usize];
+        debug_assert!(depth <= MAX_TX_DEPTH);
+      }
+      depth
+    }
+    fn bsize_to_tx_size_cat(bsize: BlockSize) -> usize {
+      let mut tx_size: TxSize = max_txsize_rect_lookup[bsize as usize];
+      debug_assert!(tx_size != TX_4X4);
+      let mut depth = 0;
+      while tx_size != TX_4X4 {
+        depth += 1;
+        tx_size = sub_tx_size_map[tx_size as usize];
+      }
+      debug_assert!(depth <= MAX_TX_CATS);
+
+      depth - 1
+    }
+
+    debug_assert!(self.bc.at(bo).is_inter() == false);
+    debug_assert!(bsize.greater_than(BlockSize::BLOCK_4X4));
+
+    let tx_size_ctx = self.get_tx_size_context(bo, bsize);
+    let depth = tx_size_to_depth(tx_size, bsize);
+
+    let max_depths = bsize_to_max_depth(bsize);
+    let tx_size_cat = bsize_to_tx_size_cat(bsize);
+
+    debug_assert!(depth <= max_depths);
+    debug_assert!(!tx_size.is_rect() || bsize.is_rect_tx_allowed());
+
+    symbol_with_update!(self, w, depth as u32,
+        &mut self.fc.tx_size_cdf[tx_size_cat][tx_size_ctx][..=max_depths+1]);
+  }
+
   pub fn get_cdf_intra_mode_kf(&self, bo: BlockOffset) -> &[u16; INTRA_MODES + 1] {
     static intra_mode_context: [usize; INTRA_MODES] =
       [0, 1, 2, 3, 4, 4, 4, 4, 3, 0, 1, 2, 0];

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -19,7 +19,7 @@ const PALETTE_COLOR_INDEX_CONTEXTS: usize = 5;
 const CDFMAX: u16 = 32768;
 const BLOCK_SIZE_GROUPS: usize = 4;
 const RESTORE_SWITCHABLE_TYPES: usize = 3;
-const TX_SIZE_CONTEXTS: usize = 3;
+pub const TX_SIZE_CONTEXTS: usize = 3;
 
 // from seg_common.h
 const MAX_SEGMENTS: usize = 8;
@@ -29,8 +29,8 @@ const SEG_TEMPORAL_PRED_CTXS: usize = 3;
 // enums.h
 const TX_SIZE_LUMA_MIN: usize = TxSize::TX_4X4 as usize;
 const TX_SIZE_CTX_MIN: usize = (TX_SIZE_LUMA_MIN + 1);
-const MAX_TX_CATS: usize = (TxSize::TX_SIZES - TX_SIZE_CTX_MIN);
-const MAX_TX_DEPTH: usize = 2;
+pub const MAX_TX_CATS: usize = (TxSize::TX_SIZES - TX_SIZE_CTX_MIN);
+pub const MAX_TX_DEPTH: usize = 2;
 
 // LUTS ---------------------
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -664,7 +664,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     // loop restoration
     self.write_frame_lrf(fi, &fs.restoration)?;
 
-    self.write_bit(false)?; // tx mode == TX_MODE_SELECT ?
+    self.write_bit(fi.tx_mode_select)?; // tx mode
 
     let mut reference_select = false;
     if !fi.intra_only {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -363,29 +363,48 @@ pub fn rdo_tx_size_type<T: Pixel>(
   cw: &mut ContextWriter, bsize: BlockSize, bo: BlockOffset,
   luma_mode: PredictionMode, ref_frames: [usize; 2], mvs: [MotionVector; 2], skip: bool
 ) -> (TxSize, TxType) {
-  // these rules follow TX_MODE_LARGEST
-  let tx_size = {
+  use crate::context::max_txsize_rect_lookup;
+  let tx_size = if fi.frame_type == FrameType::INTER || !fi.tx_mode_select {
+    max_txsize_rect_lookup[bsize as usize]
+  } else {
     use self::BlockSize::*;
     use self::TxSize::*;
     match bsize {
+      /*BLOCK_4X4 => TX_4X4,
+      BLOCK_8X8 => TX_4X4,
+      BLOCK_16X16 => TX_8X8,
+      BLOCK_4X8 => TX_4X8,
+      BLOCK_8X4 => TX_8X4,
+      BLOCK_8X16 => TX_8X8,
+      BLOCK_16X8 => TX_8X8,
+      BLOCK_16X32 => TX_16X16,
+      BLOCK_32X16 => TX_16X16,
+      BLOCK_32X32 => TX_16X16,
+      BLOCK_32X64 => TX_32X32,
+      BLOCK_64X32 => TX_32X32,
+      BLOCK_64X64 => TX_32X32,
+      _ => unimplemented!()*/
+
       BLOCK_4X4 => TX_4X4,
-      BLOCK_8X8 => TX_8X8,
-      BLOCK_16X16 => TX_16X16,
+      BLOCK_8X8 => TX_4X4,
+      BLOCK_16X16 => TX_8X8,
       BLOCK_4X8 => TX_4X8,
       BLOCK_8X4 => TX_8X4,
       BLOCK_8X16 => TX_8X16,
       BLOCK_16X8 => TX_16X8,
       BLOCK_16X32 => TX_16X32,
       BLOCK_32X16 => TX_32X16,
-      BLOCK_32X32 => TX_32X32,
+      BLOCK_32X32 => TX_16X16,
       BLOCK_32X64 => TX_32X64,
       BLOCK_64X32 => TX_64X32,
-      BLOCK_64X64 => TX_64X64,
+      BLOCK_64X64 => TX_32X32,
       _ => unimplemented!()
     }
   };
-  cw.bc.set_tx_size(bo, tx_size);
-  // Were we not hardcoded to TX_MODE_LARGEST, block tx size would be written here
+  debug_assert!(tx_size.width_log2() <= bsize.width_log2());
+  debug_assert!(tx_size.height_log2() <= bsize.height_log2());
+
+  cw.bc.set_tx_size(bo, bsize, tx_size);
 
   // Luma plane transform type decision
   let is_inter = !luma_mode.is_intra();
@@ -820,7 +839,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       false
     );
     cw.rollback(&cw_checkpoint);
-    if let Some(cfl) = rdo_cfl_alpha(fs, bo, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling) {
+    if let Some(cfl) = rdo_cfl_alpha(fs, bo, bsize, fi.sequence.bit_depth) {
       let wr: &mut dyn Writer = &mut WriterCounter::new();
       let tell = wr.tell_frac();
 
@@ -892,10 +911,10 @@ pub fn rdo_mode_decision<T: Pixel>(
 }
 
 pub fn rdo_cfl_alpha<T: Pixel>(
-  fs: &mut FrameState<T>, bo: BlockOffset, bsize: BlockSize, bit_depth: usize,
-  chroma_sampling: ChromaSampling
+  fs: &mut FrameState<T>, bo: BlockOffset, bsize: BlockSize, bit_depth: usize
 ) -> Option<CFLParams> {
-  let uv_tx_size = bsize.largest_uv_tx_size(chroma_sampling);
+  let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
+  let uv_tx_size = bsize.largest_uv_tx_size(xdec, ydec);
 
   let mut ac: AlignedArray<[i16; 32 * 32]> = UninitializedAlignedArray();
   luma_ac(&mut ac.array, fs, bo, bsize);


### PR DESCRIPTION
- tx paritions downto one level w/o any RDO (i.e. for ex, 32x32 partition will have
four of 16x16 tx for luma, while the chroma will always have only one tx)
- tx partition is for intra mode block only.
- Deblocking filter are turned off, because otherwise a mismatch arise
  between encoder and decoder's output of reconsturcted images.